### PR TITLE
ci: :sparkles: lint in docker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
-        run: |
-          cd /__w/nemchik/nemchik
-          ls -lah
-          editorconfig-checker
+        run: editorconfig-checker
 
   markdownlint:
     runs-on: ubuntu-latest
@@ -24,10 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
-        run: |
-          cd /__w/nemchik/nemchik
-          ls -lah
-          mdl -r ~MD013,~MD033,~MD034 .
+        run: mdl -r ~MD013,~MD033,~MD034 .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -37,7 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint
-        run: |
-          cd /__w/nemchik/nemchik
-          ls -lah
-          yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
          image: mstruebing/editorconfig-checker:v3.3.0
+         options: --user "$(id -u):$(id -g)"
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: markdownlint/markdownlint:0.13.0
+      options: --user "$(id -u):$(id -g)"
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
@@ -31,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: peterdavehello/yamllint:1.37.0
+      options: --user "$(id -u):$(id -g)"
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,37 +5,37 @@ on: [push, pull_request]
 jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
+    container:
+      image: mstruebing/editorconfig-checker:v3.3.0
+      volumes:
+        - ${{ github.workspace }}:/check
+      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
-        run: |
-          docker run --rm \
-            -v "${GITHUB_WORKSPACE}":/check \
-            -u "$(id -u):$(id -g)" \
-            mstruebing/editorconfig-checker
+        run: editorconfig-checker
 
   markdownlint:
     runs-on: ubuntu-latest
+    container:
+      image: markdownlint/markdownlint:0.13.0
+      volumes:
+        - ${{ github.workspace }}:/data
+      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
-        run: |
-          find "${GITHUB_WORKSPACE}" -name '*.md' -exec \
-            docker run --rm \
-              -v "${GITHUB_WORKSPACE}":"${GITHUB_WORKSPACE}" \
-              markdownlint/markdownlint \
-              -r ~MD013,~MD033,~MD034 \
-              {} +
+        run: mdl -r ~MD013,~MD033,~MD034 .
+
 
   yamllint:
     runs-on: ubuntu-latest
+    container:
+      image: peterdavehello/yamllint:1.37.0
+      volumes:
+        - ${{ github.workspace }}:/yaml
+      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint
-        run: |
-          find "${GITHUB_WORKSPACE}" -name '*.yaml' -o -name '*.yml' -exec \
-            docker run --rm \
-              -v "${GITHUB_WORKSPACE}":"${GITHUB_WORKSPACE}" \
-              peterdavehello/yamllint \
-              yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' \
-              {} +
+        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mstruebing/editorconfig-checker:v3.3.0
-      volumes:
-        - ${{ github.workspace }}:/check
-      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -19,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: markdownlint/markdownlint:0.13.0
-      volumes:
-        - ${{ github.workspace }}:/data
-      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
@@ -32,9 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: peterdavehello/yamllint:1.37.0
-      volumes:
-        - ${{ github.workspace }}:/yaml
-      options: --user=$(id -u):$(id -g)
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ jobs:
     container:
          image: mstruebing/editorconfig-checker:v3.3.0
     steps:
+      - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
         run: |
           cd /__w/nemchik/nemchik
@@ -19,6 +20,7 @@ jobs:
     container:
       image: markdownlint/markdownlint:0.13.0
     steps:
+      - uses: actions/checkout@v4.2.2
       - name: markdownlint
         run: |
           cd /__w/nemchik/nemchik
@@ -30,6 +32,7 @@ jobs:
     container:
       image: peterdavehello/yamllint:1.37.0
     steps:
+      - uses: actions/checkout@v4.2.2
       - name: yamllint
         run: |
           cd /__w/nemchik/nemchik

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ jobs:
     container:
       image: mstruebing/editorconfig-checker:v3.3.0
     steps:
-      - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
         run: editorconfig-checker
 
@@ -17,7 +16,6 @@ jobs:
     container:
       image: markdownlint/markdownlint:0.13.0
     steps:
-      - uses: actions/checkout@v4.2.2
       - name: markdownlint
         run: mdl -r ~MD013,~MD033,~MD034 .
 
@@ -27,6 +25,5 @@ jobs:
     container:
       image: peterdavehello/yamllint:1.37.0
     steps:
-      - uses: actions/checkout@v4.2.2
       - name: yamllint
         run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-         image: mstruebing/editorconfig-checker:v3.3.0
-         options: --user 0:0
+      image: mstruebing/editorconfig-checker:v3.3.0
+      options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd /__w/nemchik/nemchik
           ls -lah
-          mdl .
+          mdl -r ~MD013,~MD033,~MD034 .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -40,4 +40,4 @@ jobs:
         run: |
           cd /__w/nemchik/nemchik
           ls -lah
-          yamllint .
+          yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-      image: mstruebing/editorconfig-checker:v3.3.0
+      image: mstruebing/editorconfig-checker:v3.2.1
       options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
@@ -16,7 +16,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     container:
-      image: markdownlint/markdownlint:0.13.0
+      image: markdownlint/markdownlint:0.12.0
       options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
@@ -26,7 +26,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     container:
-      image: peterdavehello/yamllint:1.37.0
+      image: peterdavehello/yamllint:1.36.0
       options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-       image: mstruebing/editorconfig-checker:v3.3.0
-       options: --user 0:0
+      image: mstruebing/editorconfig-checker:v3.3.0
+      options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
-        run: mdl .
+        run: mdl -r ~MD013,~MD033,~MD034 .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint
-        run: yamllint .
+        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-        image: mstruebing/editorconfig-checker:v3.3.0
+      image: mstruebing/editorconfig-checker:v3.3.0
     steps:
       - name: editorconfig-checker
         run: editorconfig-checker
@@ -17,7 +17,7 @@ jobs:
       image: markdownlint/markdownlint:0.13.0
     steps:
       - name: markdownlint
-        run: mdl .
+        run: mdl -r ~MD013,~MD033,~MD034 .
 
 
   yamllint:
@@ -26,4 +26,4 @@ jobs:
       image: peterdavehello/yamllint:1.37.0
     steps:
       - name: yamllint
-        run: yamllint .
+        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
          image: mstruebing/editorconfig-checker:v3.3.0
-         options: --user "$(id -u):$(id -g)"
+         options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: markdownlint/markdownlint:0.13.0
-      options: --user "$(id -u):$(id -g)"
+      options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: peterdavehello/yamllint:1.37.0
-      options: --user "$(id -u):$(id -g)"
+      options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,9 @@ jobs:
       image: mstruebing/editorconfig-checker:v3.3.0
     steps:
       - name: editorconfig-checker
-        run: editorconfig-checker
+        run: |
+          cd /__w/nemchik/nemchik
+          editorconfig-checker
 
   markdownlint:
     runs-on: ubuntu-latest
@@ -17,7 +19,9 @@ jobs:
       image: markdownlint/markdownlint:0.13.0
     steps:
       - name: markdownlint
-        run: mdl -r ~MD013,~MD033,~MD034 .
+        run: |
+          cd /__w/nemchik/nemchik
+          mdl -r ~MD013,~MD033,~MD034 .
 
 
   yamllint:
@@ -26,4 +30,6 @@ jobs:
       image: peterdavehello/yamllint:1.37.0
     steps:
       - name: yamllint
-        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+        run: |
+          cd /__w/nemchik/nemchik
+          yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-      image: mstruebing/editorconfig-checker:v3.3.0
+        image: mstruebing/editorconfig-checker:v3.3.0
     steps:
       - name: editorconfig-checker
         run: editorconfig-checker
@@ -17,7 +17,7 @@ jobs:
       image: markdownlint/markdownlint:0.13.0
     steps:
       - name: markdownlint
-        run: mdl -r ~MD013,~MD033,~MD034 .
+        run: mdl .
 
 
   yamllint:
@@ -26,4 +26,4 @@ jobs:
       image: peterdavehello/yamllint:1.37.0
     steps:
       - name: yamllint
-        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+        run: yamllint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-      image: mstruebing/editorconfig-checker:v3.3.0
-      options: --user 0:0
+       image: mstruebing/editorconfig-checker:v3.3.0
+       options: --user 0:0
     steps:
       - uses: actions/checkout@v4.2.2
       - name: editorconfig-checker
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: markdownlint
-        run: mdl -r ~MD013,~MD033,~MD034 .
+        run: mdl .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: yamllint
-        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+        run: yamllint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,12 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     container:
-      image: mstruebing/editorconfig-checker:v3.3.0
+         image: mstruebing/editorconfig-checker:v3.3.0
     steps:
       - name: editorconfig-checker
         run: |
           cd /__w/nemchik/nemchik
+          ls -lah
           editorconfig-checker
 
   markdownlint:
@@ -21,8 +22,8 @@ jobs:
       - name: markdownlint
         run: |
           cd /__w/nemchik/nemchik
-          mdl -r ~MD013,~MD033,~MD034 .
-
+          ls -lah
+          mdl .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -32,4 +33,5 @@ jobs:
       - name: yamllint
         run: |
           cd /__w/nemchik/nemchik
-          yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+          ls -lah
+          yamllint .


### PR DESCRIPTION
Signed-off-by: Eric Nemchik <eric@nemchik.com>

## Summary by Sourcery

Run linting checks in dedicated container environments using the GitHub Actions `container` option and simplify commands accordingly.

Enhancements:
- Replace manual `docker run` invocations in run steps with direct linter commands (`editorconfig-checker`, `mdl`, `yamllint`)

CI:
- Use the `container` directive for editorconfig-checker, markdownlint, and yamllint jobs to pull and run the appropriate images
- Mount the workspace and set user permissions at the job level instead of in individual `docker run` commands