### PR TITLE
ci: :green_heart: use lint tool confs and switch ci images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Build mkdocs and deploy to GitHub Pages
 on: [push, pull_request]
 
 jobs:
-
   build:
     name: Build docs
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,17 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: editorconfig-checker
-        run: editorconfig-checker
+        run: editorconfig-checker .
 
   markdownlint:
     runs-on: ubuntu-latest
     container:
-      image: markdownlint/markdownlint:0.13.0@sha256:25c930bb03b1ea50a2e6e377e4ab6f1fe89a760f85e56d189cc007caa4301b0b
+      image: davidanson/markdownlint-cli2:v0.18.1
       options: --user 0:0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: markdownlint
-        run: mdl -r ~MD013,~MD033,~MD034 .
+        run: markdownlint-cli2 .
 
   yamllint:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: yamllint
-        run: yamllint -d '{"extends":"default","rules":{"document-start":{"present":false},"line-length":"disable","truthy":{"check-keys":false}}}' .
+        run: yamllint .

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,13 @@
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+
+# Default state for all rules
+default: true
+
+# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
+MD013: false
+
+# MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md
+MD033: false
+
+# MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md
+MD034: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start:
+    present: false
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/README.md
+++ b/README.md
@@ -1,42 +1,26 @@
 # About Me
 
-Hello, I’m Eric Nemchik.
+Hello, I'm Eric Nemchik.
 
 I am a Solution Architect, Software Developer, and DevOps Engineer with a passion for automation.
 
 ## What I'm up to
 
-<!--
-**nemchik/nemchik** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
-Here are some ideas to get you started:
-
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
-
--->
-
-### 🔭 I’m currently working on
+### 🔭 I'm currently working on
 
 Expanding my knowledge and experience with the skills and hobbies I love!
 
-### 🌱 I’m currently learning
+### 🌱 I'm currently learning
 
 ![Discord.js](https://img.shields.io/static/v1?style=flat-square&logo=discord&logoColor=white&label=&labelColor=5865F2&message=Discord.js&color=16171d)
 ![React](https://img.shields.io/static/v1?style=flat-square&logo=react&logoColor=white&label=&labelColor=61DAFB&message=React&color=16171d)
 ![Next.js](https://img.shields.io/static/v1?style=flat-square&logo=nextdotjs&logoColor=white&label=&labelColor=000000&message=Next.js&color=16171d)
 
-### 👯 I’m looking to collaborate on
+### 👯 I'm looking to collaborate on
 
 Automating everything!
 
-### 🤔 I’m looking for help with
+### 🤔 I'm looking for help with
 
 Sleep.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,6 @@ plugins:
         u/buyshared.md: https://my.frantech.ca/aff.php?aff=1555&site=buyshared
         u/buyvm.md: https://my.frantech.ca/aff.php?aff=1555&site=buyvm
         u/nextdns.md: https://nextdns.io/?from=yyd3e6sy
-  # - search
 
 nav:
   - About Me: index.md


### PR DESCRIPTION
Signed-off-by: Eric Nemchik <eric@nemchik.com>

## Summary by Sourcery

Update linting configurations and workflows, and clean up project documentation

Enhancements:
- Centralize lint rules into new .markdownlint.yml and .yamllint.yml files
- Remove obsolete mkdocs search plugin entry

CI:
- Add explicit path argument to editorconfig-checker step
- Switch markdownlint CI job to use davidanson/markdownlint-cli2 image and CLI
- Remove inline lint configurations from yamllint step

Documentation:
- Standardize apostrophes and remove placeholder content from README