### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Build mkdocs and deploy to GitHub Pages
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build docs
+  mkdocs:
+    name: Build and Deploy mkdocs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,35 +32,6 @@ jobs:
         run: pip install -r docs/requirements.txt
       - name: Build documentation
         run: mkdocs build
-
-  deploy:
-    if: github.event_name == 'push' && contains(fromJson('["refs/heads/master", "refs/heads/main"]'), github.ref)
-    needs: build
-    name: Deploy docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          sparse-checkout: |
-            docs
-      - name: Setup python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: 3.13.5
-      - name: Get pip cache directory
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: Cache dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: pip install -r docs/requirements.txt
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && contains(fromJson('["refs/heads/master", "refs/heads/main"]'), github.ref)
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary by Sourcery

Simplify the GitHub Actions workflow by merging the build and deploy jobs into a single mkdocs job, renaming it, and removing redundant deployment steps.

CI:
- Merge the separate build and deploy jobs into a single 'mkdocs' job that performs both building and deploying.
- Rename the 'build' job to 'mkdocs' and update its display name to 'Build and Deploy mkdocs'.
- Remove the standalone 'deploy' job and inline the deploy step with a conditional into the mkdocs job.