### PR TITLE
ci: improve step names

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and Deploy mkdocs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,8 @@ jobs:
       image: mstruebing/editorconfig-checker:v3.3.0@sha256:a04d1bf7c8c7e01534e11ce9253d66721d7b039722ce514910c59bb68ce14f50
       options: --user 0:0
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: editorconfig-checker
         run: editorconfig-checker .
 
@@ -19,7 +20,8 @@ jobs:
       image: davidanson/markdownlint-cli2:v0.18.1@sha256:173cb697a255a8a985f2c6a83b4f7a8b3c98f4fb382c71c45f1c52e4d4fed63a
       options: --user 0:0
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: markdownlint
         run: markdownlint-cli2 **.{md,markdown}
 
@@ -29,6 +31,7 @@ jobs:
       image: peterdavehello/yamllint:1.37.0@sha256:bb8e9a2970f31503714447e2c309add8eb27ad57a66dee6fa2d37322415ed0ae
       options: --user 0:0
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: yamllint
         run: yamllint .

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - name: Stale
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

## Summary by Sourcery

Standardize step naming across GitHub Actions workflows by adding explicit names to checkout and stale action steps

CI:
- Add explicit "Checkout" step name to lint, markdownlint, yamllint, and deploy-mkdocs jobs
- Add explicit "Stale" step name to the stale workflow